### PR TITLE
Small fix for zip file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@ cd blender-2.5/exporter/
 version=$(cat osg/__init__.py | grep 'VERSION' | sed 's/VERSION.*"\(.*\)"/\1/')
 appname=osgexport-$version
 echo $appname
-zip -r ../build/${appname}.zip .
+zip -r ../build/${appname}.zip . -i \*.py


### PR DESCRIPTION
build.sh is compressing every file it finds under the code directory, .pyc files, temporaries... This will only pack python source files.
