### PR TITLE
Fix for blender versions <=2.59 where "from bpy.types import Operator" f...

### DIFF
--- a/blender-2.5/exporter/osg/osgbake.py
+++ b/blender-2.5/exporter/osg/osgbake.py
@@ -19,7 +19,6 @@
 # <pep8-80 compliant>
 
 import bpy
-from bpy.types import Operator
 from . import osglog
 
 def pose_frame_info(obj):
@@ -242,7 +241,7 @@ def bake(scene,
 from bpy.props import IntProperty, BoolProperty, EnumProperty
 
 
-class BakeAction(Operator):
+class BakeAction(bpy.types.Operator):
     '''Bake animation to an Action'''
     bl_idname = "osg.bake"
     bl_label = "Bake Action"


### PR DESCRIPTION
Here you have the rebased version against your current repository.

Thanks!
