### PR TITLE
DrawElementsUInt fix

### DIFF
--- a/blender-2.5/exporter/osg/osgobject.py
+++ b/blender-2.5/exporter/osg/osgobject.py
@@ -869,7 +869,7 @@ class DrawElements(Object):
     def getSizeArray(self):
         # dont waste time here
         # return max drawElements
-        return "DrawElementsUInt"
+        # return "DrawElementsUInt"
         element = "DrawElementsUByte"
         for i in self.indexes:
             if i > 255 and element == "DrawElementsUByte":


### PR DESCRIPTION
Disabled the use of DrawElementsUInt by default for every mesh - allows export for OpenGL ES too
