### PR TITLE
Modifications to make the exporter consistent with OSG examples

### DIFF
--- a/blender-2.5/exporter/osg/__init__.py
+++ b/blender-2.5/exporter/osg/__init__.py
@@ -35,7 +35,7 @@ bl_info = {
     "wiki_url": "https://github.com/cedricpinson/osgexport/wiki",
     "tracker_url": "http://github.com/cedricpinson/osgexport",
     "category": "Import-Export"}
-    
+
 __version__ = bl_info["version"]
 __author__  = bl_info["author"]
 __email__   = bl_info["email"]
@@ -125,7 +125,7 @@ except:
 
 
 # Property subtype constant changed with r50938
-FILE_NAME = "FILE_NAME" if bpy.app.build_revision >= b'50938' else "FILENAME"
+FILE_NAME = "FILE_NAME" if int(bpy.app.build_revision) >= 50938 else "FILENAME"
 
 class OSGGUI(bpy.types.Operator, ExportHelper):
     '''Export model data to an OpenSceneGraph file'''
@@ -133,10 +133,10 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
     bl_label = "OSG Model"
 
     filename_ext = ".osgt"
-    
+
     # List of operator properties, the attributes will be assigned
     # to the class instance from the operator settings before calling.
-    
+
     AUTHOR = StringProperty(name="Author", description="Name of the Author of this model", default="")
     SELECTED = BoolProperty(name="Only Export Selected", description="Only export the selected model", default=False)
     ONLY_VISIBLE = BoolProperty(name="Only Export Visible", description="Only export the visible models", default=False)
@@ -157,10 +157,10 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
     TEXTURE_PREFIX = StringProperty(name="texture prefix", default="")
     EXPORT_ALL_SCENES = BoolProperty(name="Export all scenes", default=False)
     ZERO_TRANSLATIONS = BoolProperty(name="Zero world translations", default=False)
-   
+
     def draw(self, context):
         layout = self.layout
-        
+
         layout.row(align=True).label("Author:")
         layout.row(align=True).prop(self, "AUTHOR", text="")
         layout.row(align=True).prop(self, "SELECTED")
@@ -183,11 +183,11 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         layout.row(align=True).prop(self, "OSGCONV_PATH", text="")
         layout.row(align=True).prop(self, "RUN_VIEWER")
         layout.row(align=True).prop(self, "VIEWER_PATH", text="")
-        
+
     def invoke(self, context, event):
         print("config is " + bpy.utils.user_resource('CONFIG'))
         self.config = osgconf.Config()
-        
+
         try:
             cfg = os.path.join(bpy.utils.user_resource('CONFIG'), "osgExport.cfg")
             if os.path.exists(cfg):
@@ -195,15 +195,15 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
                     self.config = pickle.load(f)
         except Exception:
             pass
-        
+
         self.config.activate()
-            
+
         self.SELECTED = (self.config.selected == "SELECTED_ONLY_WITH_CHILDREN")
         self.ONLY_VISIBLE = self.config.only_visible
         self.INDENT = self.config.indent
         self.FLOATPRE = self.config.float_precision
         self.ANIMFPS = context.scene.render.fps
-        
+
         self.EXPORTANIM = self.config.export_anim
         self.APPLYMODIFIERS = self.config.apply_modifiers
         self.ZERO_TRANSLATIONS = self.config.zero_translations
@@ -214,25 +214,25 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.OSGCONV_EMBED_TEXTURES = self.config.osgconv_embed_textures
         self.OSGCONV_PATH = self.config.osgconv_path
         self.OSGCONV_CLEANUP = self.config.osgconv_cleanup
-        
+
         self.RUN_VIEWER = self.config.run_viewer
         self.VIEWER_PATH = self.config.viewer_path
         self.TEXTURE_PREFIX = self.config.texture_prefix
         self.EXPORT_ALL_SCENES = self.config.export_all_scenes
-        
+
         if bpy.data.filepath in self.config.history:
             self.filepath = self.config.history[bpy.data.filepath]
-        
+
         return super(OSGGUI, self).invoke(context, event)
-    
+
     def execute(self, context):
         if not self.filepath:
             raise Exception("filepath not set")
 
         self.config.initFilePaths(self.filepath)
-        
+
         self.config.history[bpy.data.filepath] = self.filepath
-        
+
         if self.SELECTED:
             self.config.selected = "SELECTED_ONLY_WITH_CHILDREN"
         else:
@@ -255,14 +255,14 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.config.osgconv_embed_textures = self.OSGCONV_EMBED_TEXTURES
         self.config.export_all_scenes = self.EXPORT_ALL_SCENES
         self.config.osgconv_cleanup = self.OSGCONV_CLEANUP
-        
+
         try:
             cfg = os.path.join(bpy.utils.user_resource('CONFIG'), "osgExport.cfg")
             with open(cfg, 'wb') as f:
                 pickle.dump(self.config, f)
         except Exception:
             pass
-        
+
         if self.config.export_all_scenes:
             for scene in bpy.data.scenes:
                 self.config.scene = scene
@@ -275,5 +275,5 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
             print("FILENAME:" + repr(self.config.filename))
             self.config.scene = bpy.context.scene
             OpenSceneGraphExport(self.config)
-            
+
         return {'FINISHED'}

--- a/blender-2.5/exporter/osg/osgobject.py
+++ b/blender-2.5/exporter/osg/osgobject.py
@@ -86,7 +86,7 @@ class Writer(object):
 
     def write(self, output):
         Writer.serializeInstanceOrUseIt(self, output)
-        
+
     def encode(self, string):
         text = string.replace("\t", "").replace("#", (" " * INDENT)).replace("$", (" " * (INDENT*self.indent_level) ))
         return text.encode('utf-8')
@@ -220,7 +220,7 @@ class DefaultUserDataContainer(Object):
             s.indent_level = self.indent_level + 2
             s.write(output)
         output.write(self.encode("$#}\n"))
-        
+
 
 class UpdateMatrixTransform(Object):
     def __init__(self, *args, **kwargs):
@@ -364,7 +364,7 @@ class StackedQuaternionElement(Object):
         m = Matrix().to_4x4()
         m.identity()
         self.quaternion = m.to_quaternion()
-        self.name = "quaternion"
+        self.name = "rotate"
 
     def className(self):
         return "StackedQuaternionElement"
@@ -499,7 +499,7 @@ class MatrixTransform(Group):
         Group.__init__(self, *args, **kwargs)
         self.matrix = Matrix().to_4x4()
         self.matrix.identity()
-    
+
     def className(self):
         return "MatrixTransform"
 
@@ -652,7 +652,7 @@ class Image(Object):
         Object.serializeContent(self, output)
         output.write(self.encode("$#FileName \"%s\"\n" % self.filename))
         output.write(self.encode("$#WriteHint 0 2\n"))
-    
+
 
 class Material(StateAttribute):
     def __init__(self, *args, **kwargs):
@@ -734,7 +734,7 @@ class StateSet(Object):
         output.write(self.encode("$}\n"))
 
     def serializeContent(self, output):
-        
+
         if len(self.modes) > 0:
             output.write(self.encode("$#ModeList %d {\n" % (len(self.modes))))
             for i in self.modes.items():
@@ -899,7 +899,7 @@ class DrawElements(Object):
             output.write(self.encode("\n") )
         output.write(self.encode("$#}\n"))
 
-    
+
 class Geometry(Object):
     def __init__(self, *args, **kwargs):
         Object.__init__(self, *args, **kwargs)
@@ -978,7 +978,7 @@ class Bone(MatrixTransform):
     def buildBoneChildren(self):
         if self.skeleton is None or self.bone is None:
             return
-        
+
         self.setName(self.bone.name)
         update_callback = UpdateBone()
         update_callback.setName(self.name)
@@ -991,10 +991,19 @@ class Bone(MatrixTransform):
             bone_matrix = parent_matrix.inverted() * bone_matrix
 
         # add bind matrix in localspace callback
-        update_callback.stacked_transforms.append(StackedMatrixElement(name = "bindmatrix", matrix = bone_matrix))
-        update_callback.stacked_transforms.append(StackedTranslateElement())
-        update_callback.stacked_transforms.append(StackedQuaternionElement())
-        update_callback.stacked_transforms.append(StackedScaleElement())
+        #update_callback.stacked_transforms.append(StackedMatrixElement(name = "bindmatrix", matrix = bone_matrix))
+
+        t = StackedTranslateElement()
+        t.translate = bone_matrix.to_translation()
+        update_callback.stacked_transforms.append(t)
+
+        q = StackedQuaternionElement()
+        q.quaternion = bone_matrix.to_quaternion()
+        update_callback.stacked_transforms.append(q)
+
+        s = StackedScaleElement()
+        s.scale = bone_matrix.to_scale()
+        update_callback.stacked_transforms.append(s)
 
         self.bone_inv_bind_matrix_skeleton = self.bone.matrix_local.copy().inverted()
         if not self.bone.children:
@@ -1161,7 +1170,7 @@ class Animation(Object):
         Object.__init__(self, *args, **kwargs)
         self.generateID()
         self.channels = []
-    
+
     def className(self):
         return "Animation"
 
@@ -1190,7 +1199,7 @@ class Channel(Object):
 
     def generateID(self):
         return None
-    
+
     def className(self):
         return "Channel"
 


### PR DESCRIPTION
Hello Cedric, 

I have encountered problems while trying to use the exporter with osgAnimation code based on the OSG examples. It seems that there are some inconsistencies, namely the naming of the quaternion stacked transform ("quaternion" vs "rotate" in the examples) and the way the skeleton pose is exported. OSG is using translation/quaternion/scale as the rest pose from which the animations are referenced, however your exporter exports these as identity transform and exports a matrix called "bindmatrix" instead - which is ignored by the OSG examples. 

I have changed the code to match with the OSG example code, but probably you had your own reason why did you do things in the way you did, that's why I have it a branch for the time being. However, it would be good to fix this, because it will trip up anyone who follows the examples and then tries to use your exporter to actually produce some animated models.

I have also fixed one version check (the FILENAME vs FILE_NAME issue) that was tested  incorrectly and was crashing for me inside Blender while debugging (b'foo' creates a byte array and this was being compared to a string => crash due to incompatible types). 

Regards,

Jan
