### PR TITLE
Do not set StateSets to DYNAMIC dataVariance

### DIFF
--- a/blender-2.5/exporter/osg/osgdata.py
+++ b/blender-2.5/exporter/osg/osgdata.py
@@ -1097,7 +1097,6 @@ class BlenderObjectToGeometry(object):
         stateset.attributes.append(material)
 
         for osg_object in (stateset, material):
-            osg_object.dataVariance = "DYNAMIC"
             osg_object.setName(mat_source.name)
             osg_object.getOrCreateUserData().append(StringValueObject("source", "blender"))
 
@@ -1215,6 +1214,8 @@ class BlenderObjectToGeometry(object):
         """
         anim = createAnimationMaterialAndSetCallback(material, mat_source, self.config, self.unique_objects)
         if anim:
+            for osg_object in (stateset, material):
+                stateset.dataVariance = "DYNAMIC";
             self.material_animations[anim.name] = anim
 
         if mat_source.use_shadeless:


### PR DESCRIPTION
Doing so makes the exported models slow to render. If there are Drawables or StateSets set to DYNAMIC in the scene graph, OSG has to wait until the draw traversal processed that Drawable / StateSet before commencing the next frame.

In this case, the exported StateSets do not have a callback attached, nor are they otherwise updated so a DYNAMIC data variance is unnecessary. 