### PR TITLE
Convert the normals for rotated and (unevenly) scaled objects

### DIFF
--- a/exporter/osg/__init__.py
+++ b/exporter/osg/__init__.py
@@ -26,7 +26,7 @@ import argparse
 bl_info = {
     "name": "Export OSG format (.osgt)",
     "author": "Cedric Pinson, Jeremy Moles, Peter Amstutz",
-    "version": (0, 15, 0),
+    "version": (0, 15, 1),
     "blender": (2, 7, 6),
     "email": "trigrou@gmail.com, jeremy@emperorlinux.com, peter.amstutz@tseboston.com",
     "api": 36339,

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1465,7 +1465,12 @@ use an uv layer '{}' that does not exist on the mesh '{}'; using the first uv ch
             if face.use_smooth:
                 normal = list(mesh.vertices[face.vertices[facevertexindex]].normal)
             else:
-                normal = list(face.normal)
+                # Convert the normals for rotated and (unevenly) scaled objects
+                matrix = self.object.matrix_world
+                normal_local = face.normal.to_4d()
+                normal_local.w = 0
+                normal_local = (matrix * normal_local).to_3d()
+                normal = list(normal_local)
 
             if vertex_colors:
                 vcolors = tuple(getattr(vertex_colors.data[faceindex], 'color{}'.format(facevertexindex + 1)))


### PR DESCRIPTION
Flat normals does not appear correctly if there where unevenly transformed.
![fix_normals](https://user-images.githubusercontent.com/18647218/33548435-735215da-d8e7-11e7-8ce3-403e7eb8b1d3.png)
