### PR TITLE
[#D3D-4309] Fixes inconsistent UV order when no texture

### DIFF
--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -30,6 +30,7 @@ import shutil
 import subprocess
 
 import osg
+from collections import OrderedDict
 from . import osglog
 from . import osgconf
 from .osgutils import *
@@ -1004,7 +1005,7 @@ class BlenderObjectToGeometry(object):
         uvs = geom.uvs
         if DEBUG:
             Log("geometry uvs {}".format(uvs))
-        geom.uvs = {}
+        geom.uvs = OrderedDict()
 
         texture_list = material.texture_slots
         if DEBUG:
@@ -1446,7 +1447,7 @@ use an uv layer '{}' that does not exist on the mesh '{}'; using the first uv ch
         osg_normals = NormalArray()
         osg_colors = ColorArray()
 
-        osg_uvs = {}
+        osg_uvs = OrderedDict()
         lines = DrawElements()
         lines.type = "GL_LINES"
         triangles = DrawElements()

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -23,6 +23,7 @@
 import bpy
 import json
 import mathutils
+from collections import OrderedDict
 
 Matrix = mathutils.Matrix
 Vector = mathutils.Vector
@@ -1052,7 +1053,7 @@ class Geometry(Object):
         self.vertexes = None
         self.normals = None
         self.colors = None
-        self.uvs = {}
+        self.uvs = OrderedDict()
         self.stateset = None
         self.update_callbacks = []
 


### PR DESCRIPTION
Uses an OrderedDict to keep uv order consistent between several processing.

Note: osgexport have been run on these changes