### PR TITLE
Reset Translation when zero world translation is checked

### DIFF
--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -363,7 +363,8 @@ class Export(object):
             osg_object.matrix = matrix.copy()
             if self.config.zero_translations and parent is None:
                 if bpy.app.version[0] >= 2 and bpy.app.version[1] >= 62:
-                    print("zero_translations option has not been converted to blender 2.62")
+                    #print("zero_translations option has not been converted to blender 2.62")
+                    osg_object.matrix.translation = Vector((0.0, 0.0, 0.0))
                 else:
                     osg_object.matrix[3].xyz = Vector()
 


### PR DESCRIPTION
Instead of having only a comment I've added an effect that reset the translation of a model when the user checks the zero translation checkbox. (Tested on Blender 2.79)